### PR TITLE
Add goods CRUD page

### DIFF
--- a/app/Http/Controllers/GoodsController.php
+++ b/app/Http/Controllers/GoodsController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Goods;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class GoodsController extends Controller
+{
+    /**
+     * Display a listing of the goods.
+     */
+    public function index(): Response
+    {
+        return Inertia::render('goods/index', [
+            'goods' => Goods::all(),
+        ]);
+    }
+
+    /**
+     * Store a newly created good in storage.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'unit' => ['required', 'string', 'max:255'],
+            'fe' => ['required', 'numeric'],
+        ]);
+
+        Goods::create($validated);
+
+        return redirect()->route('goods.index');
+    }
+
+    /**
+     * Update the specified good in storage.
+     */
+    public function update(Request $request, Goods $goods): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'unit' => ['required', 'string', 'max:255'],
+            'fe' => ['required', 'numeric'],
+        ]);
+
+        $goods->update($validated);
+
+        return redirect()->route('goods.index');
+    }
+
+    /**
+     * Remove the specified good from storage.
+     */
+    public function destroy(Goods $goods): RedirectResponse
+    {
+        $goods->delete();
+
+        return redirect()->route('goods.index');
+    }
+}
+

--- a/app/Models/Goods.php
+++ b/app/Models/Goods.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Goods extends Model
+{
+    use HasFactory;
+
+    protected $table = 'goods';
+
+    protected $fillable = [
+        'name',
+        'unit',
+        'fe',
+    ];
+}
+

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -11,7 +11,7 @@ import { useInitials } from '@/hooks/use-initials';
 import { cn } from '@/lib/utils';
 import { type BreadcrumbItem, type NavItem, type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/react';
-import { BookOpen, Folder, LayoutGrid, Menu, Search } from 'lucide-react';
+import { BookOpen, Folder, LayoutGrid, Menu, Search, Package } from 'lucide-react';
 import AppLogo from './app-logo';
 import AppLogoIcon from './app-logo-icon';
 
@@ -20,6 +20,11 @@ const mainNavItems: NavItem[] = [
         title: 'Dashboard',
         href: '/dashboard',
         icon: LayoutGrid,
+    },
+    {
+        title: 'Goods',
+        href: '/goods',
+        icon: Package,
     },
 ];
 

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -4,7 +4,7 @@ import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
-import { BookOpen, Folder, LayoutGrid } from 'lucide-react';
+import { BookOpen, Folder, LayoutGrid, Package } from 'lucide-react';
 import AppLogo from './app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -12,6 +12,11 @@ const mainNavItems: NavItem[] = [
         title: 'Dashboard',
         href: '/dashboard',
         icon: LayoutGrid,
+    },
+    {
+        title: 'Goods',
+        href: '/goods',
+        icon: Package,
     },
 ];
 

--- a/resources/js/pages/goods/index.tsx
+++ b/resources/js/pages/goods/index.tsx
@@ -1,0 +1,117 @@
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Form, Head, Link } from '@inertiajs/react';
+
+interface Goods {
+    id: number;
+    name: string;
+    unit: string;
+    fe: string;
+}
+
+interface GoodsPageProps {
+    goods: Goods[];
+}
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Goods',
+        href: '/goods',
+    },
+];
+
+export default function GoodsIndex({ goods }: GoodsPageProps) {
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Goods" />
+            <div className="flex flex-col gap-8 p-4">
+                <Form method="post" action={route('goods.store')} className="space-y-4">
+                    {({ processing, errors }) => (
+                        <>
+                            <div className="grid gap-2">
+                                <Label htmlFor="name">Name</Label>
+                                <Input id="name" name="name" placeholder="Name" />
+                                <InputError className="mt-2" message={errors.name} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="unit">Unit</Label>
+                                <Input id="unit" name="unit" placeholder="Unit" />
+                                <InputError className="mt-2" message={errors.unit} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="fe">FE</Label>
+                                <Input id="fe" name="fe" type="number" step="0.01" placeholder="FE" />
+                                <InputError className="mt-2" message={errors.fe} />
+                            </div>
+                            <Button disabled={processing}>Create</Button>
+                        </>
+                    )}
+                </Form>
+
+                <div className="space-y-4">
+                    {goods.map((good) => (
+                        <Form
+                            key={good.id}
+                            method="put"
+                            action={route('goods.update', good.id)}
+                            className="flex flex-wrap items-end gap-2"
+                        >
+                            {({ processing }) => (
+                                <>
+                                    <div className="grid gap-2">
+                                        <Label htmlFor={`name-${good.id}`} className="sr-only">
+                                            Name
+                                        </Label>
+                                        <Input
+                                            id={`name-${good.id}`}
+                                            name="name"
+                                            defaultValue={good.name}
+                                            placeholder="Name"
+                                        />
+                                    </div>
+                                    <div className="grid gap-2">
+                                        <Label htmlFor={`unit-${good.id}`} className="sr-only">
+                                            Unit
+                                        </Label>
+                                        <Input
+                                            id={`unit-${good.id}`}
+                                            name="unit"
+                                            defaultValue={good.unit}
+                                            placeholder="Unit"
+                                        />
+                                    </div>
+                                    <div className="grid gap-2">
+                                        <Label htmlFor={`fe-${good.id}`} className="sr-only">
+                                            FE
+                                        </Label>
+                                        <Input
+                                            id={`fe-${good.id}`}
+                                            name="fe"
+                                            defaultValue={good.fe}
+                                            type="number"
+                                            step="0.01"
+                                            placeholder="FE"
+                                        />
+                                    </div>
+                                    <Button size="sm" disabled={processing}>
+                                        Update
+                                    </Button>
+                                    <Button variant="destructive" size="sm" asChild>
+                                        <Link href={route('goods.destroy', good.id)} method="delete" as="button">
+                                            Delete
+                                        </Link>
+                                    </Button>
+                                </>
+                            )}
+                        </Form>
+                    ))}
+                </div>
+            </div>
+        </AppLayout>
+    );
+}
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
+use App\Http\Controllers\GoodsController;
 
 Route::get('/', function () {
     return Inertia::render('welcome');
@@ -11,6 +12,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', function () {
         return Inertia::render('dashboard');
     })->name('dashboard');
+
+    Route::resource('goods', GoodsController::class)->except(['show', 'create', 'edit']);
 });
 
 require __DIR__.'/settings.php';


### PR DESCRIPTION
## Summary
- add Goods model and controller with CRUD routes
- create Goods React page and navigation links

## Testing
- `npm run lint`
- `npm run types`
- `composer test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a52e21d083319e271de66f24cf04