### PR TITLE
Add services CRUD interface

### DIFF
--- a/app/Http/Controllers/ServiceController.php
+++ b/app/Http/Controllers/ServiceController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Service;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class ServiceController extends Controller
+{
+    public function index()
+    {
+        return Inertia::render('services/index', [
+            'services' => Service::all(),
+        ]);
+    }
+
+    public function create()
+    {
+        return Inertia::render('services/create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'unit' => ['required', 'string', 'max:255'],
+            'reference_item' => ['required', 'string', 'max:255'],
+            'fe' => ['required', 'numeric'],
+        ]);
+
+        Service::create($validated);
+
+        return redirect()->route('services.index');
+    }
+
+    public function edit(Service $service)
+    {
+        return Inertia::render('services/edit', [
+            'service' => $service,
+        ]);
+    }
+
+    public function update(Request $request, Service $service)
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'unit' => ['required', 'string', 'max:255'],
+            'reference_item' => ['required', 'string', 'max:255'],
+            'fe' => ['required', 'numeric'],
+        ]);
+
+        $service->update($validated);
+
+        return redirect()->route('services.index');
+    }
+
+    public function destroy(Service $service)
+    {
+        $service->delete();
+
+        return redirect()->route('services.index');
+    }
+}
+

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Service extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'unit',
+        'reference_item',
+        'fe',
+    ];
+}
+

--- a/database/factories/ServiceFactory.php
+++ b/database/factories/ServiceFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Service;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ServiceFactory extends Factory
+{
+    protected $model = Service::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word(),
+            'unit' => $this->faker->word(),
+            'reference_item' => $this->faker->word(),
+            'fe' => $this->faker->randomFloat(2, 0, 100),
+        ];
+    }
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "cec2-app",
+    "name": "cec-app",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -36,7 +36,8 @@
                 "tailwindcss": "^4.0.0",
                 "tailwindcss-animate": "^1.0.7",
                 "typescript": "^5.7.2",
-                "vite": "^7.0.4"
+                "vite": "^7.0.4",
+                "ziggy-js": "^2.5.3"
             },
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
@@ -2642,6 +2643,12 @@
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
+        },
+        "node_modules/@types/qs": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+            "license": "MIT"
         },
         "node_modules/@types/react": {
             "version": "19.1.10",
@@ -7227,6 +7234,28 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ziggy-js": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/ziggy-js/-/ziggy-js-2.5.3.tgz",
+            "integrity": "sha512-fdlGmRpG6I7yqGicIm6xYXhfbYZHjjb5fPHF5xekK6RLQRgOgLXzEg1R6GUgmF3qPAuKTHhAJ3EUfZ86LyMGeg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/qs": "^6.9.17",
+                "qs": "~6.9.7"
+            }
+        },
+        "node_modules/ziggy-js/node_modules/qs": {
+            "version": "6.9.7",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+            "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
         "tailwindcss": "^4.0.0",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.7.2",
-        "vite": "^7.0.4"
+        "vite": "^7.0.4",
+        "ziggy-js": "^2.5.3"
     },
     "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.9.5",

--- a/resources/js/pages/services/create.tsx
+++ b/resources/js/pages/services/create.tsx
@@ -1,0 +1,50 @@
+import AppLayout from '@/layouts/app-layout';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import InputError from '@/components/input-error';
+import { Form, Head } from '@inertiajs/react';
+import { type BreadcrumbItem } from '@/types';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Services', href: '/services' },
+    { title: 'Create', href: '/services/create' },
+];
+
+export default function Create() {
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Create Service" />
+            <div className="p-4">
+                <Form method="post" action={route('services.store')} className="space-y-6">
+                    {({ errors, processing }) => (
+                        <>
+                            <div className="grid gap-2">
+                                <Label htmlFor="name">Name</Label>
+                                <Input id="name" name="name" />
+                                <InputError message={errors.name} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="unit">Unit</Label>
+                                <Input id="unit" name="unit" />
+                                <InputError message={errors.unit} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="reference_item">Reference Item</Label>
+                                <Input id="reference_item" name="reference_item" />
+                                <InputError message={errors.reference_item} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="fe">FE</Label>
+                                <Input id="fe" name="fe" type="number" step="0.01" />
+                                <InputError message={errors.fe} />
+                            </div>
+                            <Button disabled={processing}>Save</Button>
+                        </>
+                    )}
+                </Form>
+            </div>
+        </AppLayout>
+    );
+}
+

--- a/resources/js/pages/services/edit.tsx
+++ b/resources/js/pages/services/edit.tsx
@@ -1,0 +1,68 @@
+import AppLayout from '@/layouts/app-layout';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import InputError from '@/components/input-error';
+import { Form, Head } from '@inertiajs/react';
+import { type BreadcrumbItem } from '@/types';
+
+interface Service {
+    id: number;
+    name: string;
+    unit: string;
+    reference_item: string;
+    fe: string;
+}
+
+export default function Edit({ service }: { service: Service }) {
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Services', href: '/services' },
+        { title: service.name, href: `/services/${service.id}/edit` },
+    ];
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title={`Edit ${service.name}`} />
+            <div className="p-4">
+                <Form method="put" action={route('services.update', service.id)} className="space-y-6">
+                    {({ errors, processing }) => (
+                        <>
+                            <div className="grid gap-2">
+                                <Label htmlFor="name">Name</Label>
+                                <Input id="name" name="name" defaultValue={service.name} />
+                                <InputError message={errors.name} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="unit">Unit</Label>
+                                <Input id="unit" name="unit" defaultValue={service.unit} />
+                                <InputError message={errors.unit} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="reference_item">Reference Item</Label>
+                                <Input
+                                    id="reference_item"
+                                    name="reference_item"
+                                    defaultValue={service.reference_item}
+                                />
+                                <InputError message={errors.reference_item} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="fe">FE</Label>
+                                <Input
+                                    id="fe"
+                                    name="fe"
+                                    type="number"
+                                    step="0.01"
+                                    defaultValue={service.fe}
+                                />
+                                <InputError message={errors.fe} />
+                            </div>
+                            <Button disabled={processing}>Save</Button>
+                        </>
+                    )}
+                </Form>
+            </div>
+        </AppLayout>
+    );
+}
+

--- a/resources/js/pages/services/index.tsx
+++ b/resources/js/pages/services/index.tsx
@@ -1,0 +1,71 @@
+import AppLayout from '@/layouts/app-layout';
+import { Button } from '@/components/ui/button';
+import { Head, Link } from '@inertiajs/react';
+import { type BreadcrumbItem } from '@/types';
+
+interface Service {
+    id: number;
+    name: string;
+    unit: string;
+    reference_item: string;
+    fe: string;
+}
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Services', href: '/services' },
+];
+
+export default function Index({ services }: { services: Service[] }) {
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Services" />
+            <div className="p-4 space-y-4">
+                <div className="flex justify-end">
+                    <Button asChild>
+                        <Link href={route('services.create')}>Add Service</Link>
+                    </Button>
+                </div>
+                <div className="overflow-x-auto">
+                    <table className="min-w-full divide-y divide-border">
+                        <thead>
+                            <tr className="text-left">
+                                <th className="p-2">Name</th>
+                                <th className="p-2">Unit</th>
+                                <th className="p-2">Reference Item</th>
+                                <th className="p-2">FE</th>
+                                <th className="p-2"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {services.map((service) => (
+                                <tr key={service.id} className="border-b">
+                                    <td className="p-2">{service.name}</td>
+                                    <td className="p-2">{service.unit}</td>
+                                    <td className="p-2">{service.reference_item}</td>
+                                    <td className="p-2">{service.fe}</td>
+                                    <td className="p-2 space-x-2">
+                                        <Link
+                                            href={route('services.edit', service.id)}
+                                            className="text-blue-500"
+                                        >
+                                            Edit
+                                        </Link>
+                                        <Link
+                                            href={route('services.destroy', service.id)}
+                                            method="delete"
+                                            as="button"
+                                            className="text-red-500"
+                                        >
+                                            Delete
+                                        </Link>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </AppLayout>
+    );
+}
+

--- a/routes/services.php
+++ b/routes/services.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Http\Controllers\ServiceController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::resource('services', ServiceController::class);
+});
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,3 +15,4 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
 require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';
+require __DIR__.'/services.php';

--- a/tests/Feature/ServiceTest.php
+++ b/tests/Feature/ServiceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Service;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guests_are_redirected_to_login()
+    {
+        $this->get('/services')->assertRedirect('/login');
+    }
+
+    public function test_authenticated_users_can_crud_services()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $this->post('/services', [
+            'name' => 'Test Service',
+            'unit' => 'unit',
+            'reference_item' => 'item',
+            'fe' => 1.23,
+        ])->assertRedirect('/services');
+
+        $service = Service::first();
+
+        $this->put("/services/{$service->id}", [
+            'name' => 'Updated Service',
+            'unit' => 'unit',
+            'reference_item' => 'item',
+            'fe' => 2.34,
+        ])->assertRedirect('/services');
+
+        $this->delete("/services/{$service->id}")->assertRedirect('/services');
+
+        $this->assertDatabaseCount('services', 0);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Service model and factory
- implement ServiceController and routes for CRUD
- create Inertia React pages for listing, creating, and editing services
- test service CRUD access and operations

## Testing
- `npm run lint`
- `npm run types`
- `npm run build`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a1a610dffc8331a791f977bcb779b6