### PR TITLE
Add account CRUD pages

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Account;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class AccountController extends Controller
+{
+    public function index()
+    {
+        return Inertia::render('accounts/index', [
+            'accounts' => Account::all(),
+        ]);
+    }
+
+    public function create()
+    {
+        return Inertia::render('accounts/create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+        ]);
+
+        Account::create($validated);
+
+        return redirect()->route('accounts.index');
+    }
+
+    public function edit(Account $account)
+    {
+        return Inertia::render('accounts/edit', [
+            'account' => $account,
+        ]);
+    }
+
+    public function update(Request $request, Account $account)
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+        ]);
+
+        $account->update($validated);
+
+        return redirect()->route('accounts.index');
+    }
+
+    public function destroy(Account $account)
+    {
+        $account->delete();
+
+        return redirect()->route('accounts.index');
+    }
+}
+

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Account extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+    ];
+}
+

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -11,7 +11,7 @@ import { useInitials } from '@/hooks/use-initials';
 import { cn } from '@/lib/utils';
 import { type BreadcrumbItem, type NavItem, type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/react';
-import { BookOpen, Folder, LayoutGrid, Menu, Search, Package } from 'lucide-react';
+import { BookOpen, Folder, LayoutGrid, Menu, Package, Search } from 'lucide-react';
 import AppLogo from './app-logo';
 import AppLogoIcon from './app-logo-icon';
 
@@ -25,6 +25,11 @@ const mainNavItems: NavItem[] = [
         title: 'Goods',
         href: '/goods',
         icon: Package,
+    },
+    {
+        title: 'Accounts',
+        href: '/accounts',
+        icon: Folder,
     },
 ];
 

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -18,6 +18,11 @@ const mainNavItems: NavItem[] = [
         href: '/goods',
         icon: Package,
     },
+    {
+        title: 'Accounts',
+        href: '/accounts',
+        icon: Folder,
+    },
 ];
 
 const footerNavItems: NavItem[] = [

--- a/resources/js/pages/accounts/create.tsx
+++ b/resources/js/pages/accounts/create.tsx
@@ -1,0 +1,34 @@
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Form, Head } from '@inertiajs/react';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Accounts', href: '/accounts' },
+    { title: 'Create', href: '/accounts/create' },
+];
+
+export default function Create() {
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Create Account" />
+            <div className="p-4">
+                <Form method="post" action={route('accounts.store')} className="space-y-6">
+                    {({ errors, processing }) => (
+                        <>
+                            <div className="grid gap-2">
+                                <Label htmlFor="name">Name</Label>
+                                <Input id="name" name="name" />
+                                <InputError message={errors.name} />
+                            </div>
+                            <Button disabled={processing}>Save</Button>
+                        </>
+                    )}
+                </Form>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/accounts/edit.tsx
+++ b/resources/js/pages/accounts/edit.tsx
@@ -1,0 +1,39 @@
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Form, Head } from '@inertiajs/react';
+
+interface Account {
+    id: number;
+    name: string;
+}
+
+export default function Edit({ account }: { account: Account }) {
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Accounts', href: '/accounts' },
+        { title: account.name, href: `/accounts/${account.id}/edit` },
+    ];
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title={`Edit ${account.name}`} />
+            <div className="p-4">
+                <Form method="put" action={route('accounts.update', account.id)} className="space-y-6">
+                    {({ errors, processing }) => (
+                        <>
+                            <div className="grid gap-2">
+                                <Label htmlFor="name">Name</Label>
+                                <Input id="name" name="name" defaultValue={account.name} />
+                                <InputError message={errors.name} />
+                            </div>
+                            <Button disabled={processing}>Save</Button>
+                        </>
+                    )}
+                </Form>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/accounts/index.tsx
+++ b/resources/js/pages/accounts/index.tsx
@@ -1,0 +1,51 @@
+import { Button } from '@/components/ui/button';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Head, Link } from '@inertiajs/react';
+
+interface Account {
+    id: number;
+    name: string;
+}
+
+const breadcrumbs: BreadcrumbItem[] = [{ title: 'Accounts', href: '/accounts' }];
+
+export default function Index({ accounts }: { accounts: Account[] }) {
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Accounts" />
+            <div className="space-y-4 p-4">
+                <div className="flex justify-end">
+                    <Button asChild>
+                        <Link href={route('accounts.create')}>Add Account</Link>
+                    </Button>
+                </div>
+                <div className="overflow-x-auto">
+                    <table className="min-w-full divide-y divide-border">
+                        <thead>
+                            <tr className="text-left">
+                                <th className="p-2">Name</th>
+                                <th className="p-2"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {accounts.map((account) => (
+                                <tr key={account.id} className="border-b">
+                                    <td className="p-2">{account.name}</td>
+                                    <td className="space-x-2 p-2">
+                                        <Link href={route('accounts.edit', account.id)} className="text-blue-500">
+                                            Edit
+                                        </Link>
+                                        <Link href={route('accounts.destroy', account.id)} method="delete" as="button" className="text-red-500">
+                                            Delete
+                                        </Link>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/accounts.php
+++ b/routes/accounts.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Http\Controllers\AccountController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::resource('accounts', AccountController::class);
+});
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,3 +19,4 @@ Route::middleware(['auth', 'verified'])->group(function () {
 require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';
 require __DIR__.'/services.php';
+require __DIR__.'/accounts.php';


### PR DESCRIPTION
## Summary
- implement Account model and controller
- build React pages for account CRUD operations
- wire up routes and navigation for Accounts

## Testing
- `npx eslint resources/js/pages/accounts resources/js/components/app-sidebar.tsx resources/js/components/app-header.tsx`
- `npx prettier --check resources/js/pages/accounts/*.tsx resources/js/components/app-sidebar.tsx resources/js/components/app-header.tsx`
- `npm run types`
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a9f8e43c833198db8c69645c36ce